### PR TITLE
Prevent issues when checking whether domain has a 'www' subdomain

### DIFF
--- a/src/lib/Services/TLS.php
+++ b/src/lib/Services/TLS.php
@@ -83,7 +83,7 @@
         '--rsa-key-size 4096 '.implode(' ', array_map(function($domain) {
           $result = '-d '.escapeshellarg($domain);
           // Check if this domain has a 'www' subdomain
-          if (gethostbyname($domain.'.') === gethostbyname($domain = 'www.'.$domain.'.'))
+          if (gethostbyname($domain.'.invalid.') !== gethostbyname($domain = 'www.'.$domain.'.'))
             $result .= ' -d '.escapeshellarg($domain);
           // Return the resulting string for this domain
           return $result;

--- a/src/lib/Services/TLS.php
+++ b/src/lib/Services/TLS.php
@@ -83,7 +83,8 @@
         '--rsa-key-size 4096 '.implode(' ', array_map(function($domain) {
           $result = '-d '.escapeshellarg($domain);
           // Check if this domain has a 'www' subdomain
-          if (gethostbyname($domain.'.invalid.') !== gethostbyname($domain = 'www.'.$domain.'.'))
+          if ((gethostbyname($domain.'.invalid.') !== gethostbyname($domain = 'www.'.$domain.'.'))
+			      && (gethostbyname($domain) !== $domain))
             $result .= ' -d '.escapeshellarg($domain);
           // Return the resulting string for this domain
           return $result;

--- a/src/lib/Services/TLS.php
+++ b/src/lib/Services/TLS.php
@@ -83,8 +83,8 @@
         '--rsa-key-size 4096 '.implode(' ', array_map(function($domain) {
           $result = '-d '.escapeshellarg($domain);
           // Check if this domain has a 'www' subdomain
-           if ((gethostbyname($domain.'.invalid.') !== gethostbyname($domain =
-             'www.'.$domain.'.')) && (gethostbyname($domain) !== $domain))
+           if ((gethostbyname($domain = 'www.'.$domain.'.') !== gethostbyname(
+            $domain.'invalid.')) && (gethostbyname($domain) !== $domain))
             $result .= ' -d '.escapeshellarg($domain);
           // Return the resulting string for this domain
           return $result;

--- a/src/lib/Services/TLS.php
+++ b/src/lib/Services/TLS.php
@@ -83,8 +83,8 @@
         '--rsa-key-size 4096 '.implode(' ', array_map(function($domain) {
           $result = '-d '.escapeshellarg($domain);
           // Check if this domain has a 'www' subdomain
-          if ((gethostbyname($domain.'.invalid.') !== gethostbyname($domain = 'www.'.$domain.'.'))
-			      && (gethostbyname($domain) !== $domain))
+           if ((gethostbyname($domain.'.invalid.') !== gethostbyname($domain =
+             'www.'.$domain.'.')) && (gethostbyname($domain) !== $domain))
             $result .= ' -d '.escapeshellarg($domain);
           // Return the resulting string for this domain
           return $result;

--- a/src/lib/Services/TLS.php
+++ b/src/lib/Services/TLS.php
@@ -83,7 +83,7 @@
         '--rsa-key-size 4096 '.implode(' ', array_map(function($domain) {
           $result = '-d '.escapeshellarg($domain);
           // Check if this domain has a 'www' subdomain
-          if (gethostbyname($domain = 'www.'.$domain) !== $domain)
+          if (gethostbyname($domain.'.') === gethostbyname($domain = 'www.'.$domain.'.'))
             $result .= ' -d '.escapeshellarg($domain);
           // Return the resulting string for this domain
           return $result;


### PR DESCRIPTION
Prevent issues with certain DNS servers (OpenDNS) redirecting to a landing page when non-existent domains are searched for by using an intentionally invalid TLD reserved by IETF. Also prevented potentially ambiguous domain name by adding a trailing dot at the end; this prevents a domain name from being appended to the server-FQDN by nslookup.